### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM golang:latest
+FROM golang:latest as builder
 RUN mkdir /app
 ADD . /app/
 WORKDIR /app
 RUN go build -o main
-CMD ["/app/main"]
+
+FROM busybox:glibc
+WORKDIR /bin/app
+COPY --from=builder /app/main .
 EXPOSE 6379
+CMD ["/bin/app/main"]


### PR DESCRIPTION
This way you're going to get smaller final image size. 
golang:1.17 is 941MB
busybox:glibc is 5.21MB